### PR TITLE
Add hook for styling page when user prefers dark mode

### DIFF
--- a/style.css
+++ b/style.css
@@ -26,3 +26,10 @@ body {
   margin: 0em auto;
   font-size: 1000%;
 }
+
+@media (prefers-color-scheme: dark) {
+  body {
+    color: #d7d7d6;
+    background: #1c1c1c;
+  }
+}


### PR DESCRIPTION
![nov-18-2018 15-00-27](https://user-images.githubusercontent.com/14554/48677532-3851f980-eb44-11e8-8807-8b5740719918.gif)

This uses the standards-track media feature: [`prefers-color-scheme`](https://developer.mozilla.org/en-US/docs/Web/CSS/@media/prefers-color-scheme)

The only browser I know of supporting this media query is [Safari Technology Preview 70+](https://webkit.org/blog/8496/release-notes-for-safari-technology-preview-70/)

But I'm sure more browsers will follow, so we'll be ready.